### PR TITLE
USNG-3 Fix intermittent northing issue

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1614,6 +1614,19 @@ describe('Convert Lat/Lon to UTM', function(){
         chai.assert.equal(true, essentiallyEqual(east, result.east, 0.0001));
         chai.assert.equal(true, essentiallyEqual(west, result.west, 0.0001));
       });
+      it('should return 32 -102 24 -96', function(){
+        var usng = "14R";
+        var north = 32;
+        var west = -102;
+        var east = -96;
+        var south = 24;
+        var result = converter.USNGtoLL(usng, false);
+        console.log(result.north, result.south, result.east, result.west);
+        chai.assert.equal(true, essentiallyEqual(north, result.north, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(south, result.south, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(east, result.east, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(west, result.west, 0.0001));
+      });
     });
   });
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -427,7 +427,12 @@ describe('Convert Lat/Lon Bounding Box to USNG', function(){
   });
   describe('around Prescott/Chino Valley in Arizona', function(){
     it('should return 12S UD', function(){
-      chai.assert.equal("12S UD", converter.LLBboxtoUSNG(34.55, 34.45, -112.4, -112.4));
+      chai.assert.equal("12S UD", converter.LLBboxtoUSNG(34.55, 34.45, -112.4, -112.3));
+    });
+  });
+  describe('around Prescott/Chino Valley in Arizona', function(){
+    it('should return 12S UD 7 1', function(){
+      chai.assert.equal("12S UD 7 1", converter.LLBboxtoUSNG(34.50, 34.45, -112.4, -112.4));
     });
   });
   describe('immediately around Prescott city in Arizona', function(){
@@ -475,7 +480,12 @@ describe('Convert Lat/Lon Bounding Box to USNG', function(){
   });
   describe('around Toliara city in Madagascar', function(){
     it('should return 38K LA', function(){
-      chai.assert.equal("38K LA", converter.LLBboxtoUSNG(-22, -22, 43.7, 43.6));
+      chai.assert.equal("38K LA", converter.LLBboxtoUSNG(-21.9, -22, 43.7, 43.6));
+    });
+  });
+  describe('around Toliara city in Madagascar', function(){
+    it('should return 38K LA', function(){
+      chai.assert.equal("38K LA 6 6", converter.LLBboxtoUSNG(-22, -22, 43.7, 43.65));
     });
   });
   describe('around Toliara city center in Madagascar', function(){
@@ -1361,7 +1371,6 @@ describe('Convert Lat/Lon to UTM', function(){
         chai.assert.equal(Math.round(lon * 10000), Math.round(usngToLL.lon * 10000));
       });
     });
-
     describe('m-80-n and n-606 junction', function(){
       it('should return lat -36.0872 lon -72.8078', function(){
         var lat = -36.0872;
@@ -1463,7 +1472,6 @@ describe('Convert Lat/Lon to UTM', function(){
         chai.assert.equal(Math.round(lon * 10000), Math.round(usngToLL.lon * 10000));
       });
     });
-
     describe('LLBboxtoUSNG', function(){
       it('should return 18S UJ 23487 06483', function(){
         var usng = "18S UJ 23487 06483";
@@ -1500,7 +1508,7 @@ describe('Convert Lat/Lon to UTM', function(){
         var usng = "18S UJ 2 0";
         var lat = 38.8895;
         var lon = -77.0352;
-        var lon2 = -77.05;
+        var lon2 = -77.06;
         chai.assert.equal(usng, converter.LLBboxtoUSNG(lat, lat, lon, lon2));
       });
 
@@ -1594,7 +1602,6 @@ describe('Convert Lat/Lon to UTM', function(){
         chai.assert.equal(true, essentiallyEqual(east, result.east, 0.0001));
         chai.assert.equal(true, essentiallyEqual(west, result.west, 0.0001));
       });
-
       it('should return 40 -84 32 -78', function(){
         var usng = "17S";
         var north = 40;

--- a/usng.js
+++ b/usng.js
@@ -216,17 +216,20 @@
             var deltaLlamda= (westNum-eastNum)* this.DEG_2_RAD;
 
             // trigonometry calculate distance
-            var a = Math.sin(deltaPhi/2) * Math.sin(deltaPhi/2) +
-                Math.cos(phi1) * Math.cos(phi2) *
-                Math.sin(deltaLlamda/2) * Math.sin(deltaLlamda/2);
-            var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 
-            var dist = R*c;
+            var height = Math.sin(deltaPhi/2) * Math.sin(deltaPhi/2);
+            height = R * 2 * Math.atan2(Math.sqrt(height), Math.sqrt(1-height));
+            var length = Math.cos(phi1) * Math.cos(phi2) *
+                Math.sin(deltaLlamda/2) * Math.sin(deltaLlamda/2);
+            length = R * 2 * Math.atan2(Math.sqrt(length), Math.sqrt(1-length));
+
+            var dist = Math.max(height, length);
+            // divide distance by square root of two
+
 
             if (lon === 0 && (eastNum > 90 || eastNum < -90) && (westNum > 90 || westNum < -90)) {
                 lon = 180;
               }
-
             // calculate a USNG string with a precision based on distance
             // precision is defined in LLtoUSNG declaration
             var result;

--- a/usng.js
+++ b/usng.js
@@ -881,7 +881,8 @@
             }
 
             var northing = 0;
-
+            
+            if (sq2) {
             // if zone number is even, use northingArrayEven, if odd, use northingArrayOdd
             // similar to finding easting, the index of sq2 corresponds with the base easting
             if (zone%2 == 0) {
@@ -892,14 +893,20 @@
 
             // we can exploit the repeating behavior of northing to find what the total northing should be
             // iterate through the horizontal zone bands until our northing is greater than the zoneBase of our zone
-            while (northing < zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]) {
-                northing = northing + 2000000;
+            
+                while (northing < zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]) {
+                    northing = northing + 2000000;
+                    }
+
+                if (north) {
+
+                    // add the north parameter to get the total northing
+                    northing = northing+Number(north)*Math.pow(10,5-north.length);
                 }
-
-            if (north) {
-
-                // add the north parameter to get the total northing
-                northing = northing+Number(north)*Math.pow(10,5-north.length);
+            }
+            else {
+                // add approximately half of the height of one large region to ensure we're in the right zone
+                northing = zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]+499600;
             }
 
             // set return object


### PR DESCRIPTION
Northing was calculated incorrectly for certain bounding boxes.
In alternating horizontal bands, when drawing the largest zone, e.g,
12R, 13R, 17M, etc, the drawing would jump up a region. I.e, 12R would
appear where 12S is. 12S would still be in the correct place.
This seems to have been an edge case condition with the largest regions
having northings ignored. Now, when a region is the largest, it has approx.
500k added to its northing to estimate the middle and more accurately
represent its position.
@harrison-tarr 