### PR TITLE
Resolve webpack warning: "Critical dependency: require function is us…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "umd",
+    "module": "commonjs",
     "target": "es5",
     "declaration": true,
     "outDir": "./dist"


### PR DESCRIPTION
…ed in a way in which dependencies cannot be statically extracted"

I keep seeing this warning when building a project that uses this library:
```
WARNING in /projects/ddf/ui/node_modules/usng.js/dist/usng.js
41:24-31 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```

and this solution works for me: https://github.com/webpack/webpack/issues/2675#issuecomment-385073386

the github page for usng.js says `AMD compatible` so we should remove that from the description and readme.md if this PR is accepted