### PR TITLE
Remove offset value from UTM calculations

### DIFF
--- a/src/usng.ts
+++ b/src/usng.ts
@@ -487,7 +487,6 @@ extend(Converter.prototype, {
   LLtoUTMwithNS: function(lat, lon, utmcoords, zone) {
     this.LLtoUTM(lat, lon, utmcoords, zone);
     if (utmcoords[1] < 0) {
-      utmcoords[1] += this.NORTHING_OFFSET;
       utmcoords[3] = 'S';
     } else {
       utmcoords[3] = 'N';


### PR DESCRIPTION
- Removed the offset of `10,000,000 meters` from the UTM calculation. This was pushing the bounding box to the northern hemisphere. 