### PR TITLE
Add the NORTHING_OFFSET back into LLtoUtmUps

### DIFF
--- a/src/usng.ts
+++ b/src/usng.ts
@@ -487,6 +487,7 @@ extend(Converter.prototype, {
   LLtoUTMwithNS: function(lat, lon, utmcoords, zone) {
     this.LLtoUTM(lat, lon, utmcoords, zone);
     if (utmcoords[1] < 0) {
+      utmcoords[1] += this.NORTHING_OFFSET;
       utmcoords[3] = 'S';
     } else {
       utmcoords[3] = 'N';


### PR DESCRIPTION
This was originally removed, because we were adding it twice, once here and once downstream. Removing this fixed the downstream issue, but would have broken the conversion for other repos.

We located the extra NORTHING_OFFSET downstream and removed that. This corrects the issue on the repo and fixes the tests.