### PR TITLE
Add mgrs conversions

### DIFF
--- a/src/usng.ts
+++ b/src/usng.ts
@@ -1403,6 +1403,35 @@ extend(Converter.prototype, {
     }
   },
 
+  // convert MGRS to USNG by adding the appropriate spaces
+  MGRStoUSNG: function(mgrs){
+    let eastNorthSpace, squareIdEastSpace, gridZoneSquareIdSpace
+    for(let i = mgrs.length - 1; i > -1; i--){
+      // check if we have hit letters yet
+      if(isNaN(mgrs.substr(i,1))){
+          squareIdEastSpace = i + 1
+          break;
+      };
+    }
+    gridZoneSquareIdSpace = squareIdEastSpace - 2
+    let numPartLength = mgrs.substr(squareIdEastSpace).length / 2;
+    
+    eastNorthSpace = squareIdEastSpace + numPartLength;
+    let stringArray = mgrs.split("");
+    
+    stringArray.splice(eastNorthSpace, 0, " ");
+    stringArray.splice(squareIdEastSpace, 0, " ");
+    stringArray.splice(gridZoneSquareIdSpace, 0, " ");
+    
+    let rejoinedArray = stringArray.join("");
+    return rejoinedArray;
+  },
+
+  // convert MGRS to Lat Lon by chaining MGRStoUSNG and USNGtoLL together
+  MGRStoLL: function(mgrs){
+    return mgrs ? this.USNGtoLL(this.MGRStoUSNG(mgrs)) : null;
+  },
+
   // wrapper function specific to Google Maps, to make a converstion to lat/lng return a GLatLon instance.
   // takes a usng string, converts it to lat/lng using a call to USNGtoLL,
   // and returns an instance of GLatLng

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2705,3 +2705,59 @@ describe('Consistency with GEOTRANS', () => {
     });
   })
 });
+
+
+/*
+{
+    "mgrs": "31NFA0000000000",
+    "latitude": 0,
+    "longitude": 3.89864
+  },
+  {
+    "mgrs": "31NGA0000000000",
+    "latitude": 0,
+    "longitude": 4.79705
+  },
+  {
+    "mgrs": "31NHA0000000000",
+    "latitude": 0,
+    "longitude": 5.69502
+  },
+  {
+    "mgrs": "32NKF3200700000",
+    "latitude": 0,
+    "longitude": 6.59233
+  },
+  {
+    "mgrs": "30NYK6593199447",
+    "latitude": 4.5146,
+    "longitude": -0.60345
+  },
+*/
+
+describe('MGRStoUSNG', function(){
+  it('should return 31N FA 00000 00000', function(){
+    chai.assert.equal("31N FA 00000 00000", converter.MGRStoUSNG("31NFA0000000000"));
+  });
+  
+  it('should return 31N GA 00000 00000', function(){
+    chai.assert.equal("31N GA 00000 00000", converter.MGRStoUSNG("31NGA0000000000"));
+  });
+
+  it('should return 32N KF 32007 00000', function(){
+    chai.assert.equal("32N KF 32007 00000", converter.MGRStoUSNG("32NKF3200700000"));
+  });
+
+  it('should return 30N YK 65931 99447', function(){
+    chai.assert.equal("30N YK 65931 99447", converter.MGRStoUSNG("30NYK6593199447"));
+  });
+
+  it('should return 30N YK 6 5', function(){
+    chai.assert.equal("30N YK 6 5", converter.MGRStoUSNG("30NYK65"));
+  });
+
+  it('should return 30N YK 659 319', function(){
+    chai.assert.equal("30N YK 659 319", converter.MGRStoUSNG("30NYK659319"));
+  });
+});
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2706,35 +2706,6 @@ describe('Consistency with GEOTRANS', () => {
   })
 });
 
-
-/*
-{
-    "mgrs": "31NFA0000000000",
-    "latitude": 0,
-    "longitude": 3.89864
-  },
-  {
-    "mgrs": "31NGA0000000000",
-    "latitude": 0,
-    "longitude": 4.79705
-  },
-  {
-    "mgrs": "31NHA0000000000",
-    "latitude": 0,
-    "longitude": 5.69502
-  },
-  {
-    "mgrs": "32NKF3200700000",
-    "latitude": 0,
-    "longitude": 6.59233
-  },
-  {
-    "mgrs": "30NYK6593199447",
-    "latitude": 4.5146,
-    "longitude": -0.60345
-  },
-*/
-
 describe('MGRStoUSNG', function(){
   it('should return 31N FA 00000 00000', function(){
     chai.assert.equal("31N FA 00000 00000", converter.MGRStoUSNG("31NFA0000000000"));


### PR DESCRIPTION
in my use of usng.js while I could convert Lat Lon to MGRS I could not find a way to convert MGRS to Lat Lon. 

I wrote a function to convert MGRS to USNG and then used USNG's existing USNGtoLL function for converting from MGRS to Lat Lon in the MGRStoLL function.

an example is: 
`converter.MGRStoLL("4QFJ2128465763")`