### PR TITLE
Fix UPS zone letter

### DIFF
--- a/src/usng.ts
+++ b/src/usng.ts
@@ -352,7 +352,7 @@ extend(Converter.prototype, {
     const upsZoneLetter = !isUTM
       && utmups.northPole
       ? (utmups.easting < 2000000 ? 'Y' : 'Z')
-      : (utmups.northing < 2000000 ? 'A' : 'B')
+      : (utmups.easting < 2000000 ? 'A' : 'B')
     const hemisphere = utmups.northPole ? 'N' : 'S'
     const calculatedZone = isUTM ? utmups.zoneNumber + hemisphere : upsZoneLetter
     return `${calculatedZone} ${Math.round(utmups.easting)}mE ${Math.round(utmups.northing)}mN`
@@ -569,7 +569,7 @@ extend(Converter.prototype, {
     const upsObject = this.LLtoUPS(lat, lon)
     const upsZoneLetter = upsObject.northPole
       ? (upsObject.easting < 2000000 ? 'Y' : 'Z')
-      : (upsObject.northing < 2000000 ? 'A' : 'B')
+      : (upsObject.easting < 2000000 ? 'A' : 'B')
 
     return `${upsZoneLetter} ${Math.round(upsObject.easting)}mE ${Math.round(upsObject.northing)}mN`
   },


### PR DESCRIPTION
At the south pole, any longitude > -90 and < 90 (i.e. towards the prime meridian) gives the zone letter B, while longitudes > 90 but < -90 (i.e. towards the anti-meridian) gives the zone letter A. In other words, the zone letter at the south pole is being determined by the northing. This is incorrect.

[DMA TM 8358,1 B-3.2](https://apps.dtic.mil/sti/pdfs/ADA247651.pdf): 

> If the easting is less than 2,000,000 meters the Grid Zone Designation will be Y or A depending on whether the point is in the North or South Polar region. If the easting is greater than 2,000,000 meters the Grid Zone Designation will be Z or B.

See also the [wikipedia](https://upload.wikimedia.org/wikipedia/commons/8/8f/MGRSgridSouthPole.png) example.